### PR TITLE
Возможность выбора текстовика, чтобы дробить пачки

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -188,32 +188,27 @@ def GetSharedSecret(login):
         except:
             return None
 
-def ParceLogPass():
+def ParceLogPass(file):
     accounts = {}
-    file = open('logpass.txt')
-
-    for account in file:
-        if account != '\n':
-            account_pair = account.split(':')
-            accounts[account_pair[0].lower()] = {'login': account_pair[0].lower(),
-                                                 'password': account_pair[1].replace('\n', '')}
-    file.close()
+    with open(file) as file:
+        for account in file:
+            if account != '\n':
+                account_pair = account.split(':')
+                accounts[account_pair[0].lower()] = {'login': account_pair[0].lower(),
+                                                    'password': account_pair[1].replace('\n', '')}
     return accounts
 
-def CreateAccounts():
-    accounts = ParceLogPass()
+def CreateAccounts(file):
+    accounts = ParceLogPass(file)
     for login in accounts:
         accounts[login]['shared_secret'] = GetSharedSecret(login)
-
-    file = open('accounts.json', 'w', encoding='utf-8')
-    file.write(json.dumps(accounts, indent=4))
-    file.close()
+    with open('accounts.json', 'w', encoding='utf-8') as file:
+        file.write(json.dumps(accounts, indent=4))
 
 def readJson(path):
-    file = open(os.path.abspath(path), encoding='utf-8')
-    info = json.loads(file.read())
-    file.close()
-    return info
+    with open(os.path.abspath(path), encoding='utf-8') as file:
+        info = json.loads(file.read())
+        return info
 
 def OnStart():
     info = readJson('launched_accounts.json')

--- a/main.pyw
+++ b/main.pyw
@@ -3,6 +3,9 @@ import ctypes, os, sys
 try:
     os.system("pip install -r requirements.txt")
 
+    if not os.path.exists('accounts/pack'):
+        os.makedirs('accounts/pack')
+
     if ctypes.windll.shell32.IsUserAnAdmin():
         from mainwindow import *
 

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -1,11 +1,12 @@
 from PyQt5 import QtCore, QtGui, QtWidgets
-from PyQt5.QtWidgets import QDesktopWidget
+from PyQt5.QtWidgets import QDesktopWidget, QFileDialog
 from functions import *
 from settingswindow import Ui_SettingsWindow
 import threading
 
 class Ui_MainWindow(object):
     def setupUi(self, MainWindow):
+        self.file_path = 'accounts/logpass.txt'
         self.itemsToLaunch = []
         MainWindow.setObjectName("MainWindow")
         MainWindow.resize(800, 600)
@@ -118,6 +119,7 @@ class Ui_MainWindow(object):
         except:
             t1 = threading.Thread(target=self.startFarm, daemon=True)
             t1.start()
+    
     def OptimiseT(self):
         if self.opt_stat == False:
             t2 = threading.Thread(target=self.Optimise, daemon=True)
@@ -136,12 +138,6 @@ class Ui_MainWindow(object):
         th = threading.Thread(target=self.addMaFiles, daemon=True)
         th.start()
 
-    def addAccountsT(self):
-        if self.add_acc_stat == False:
-            th = threading.Thread(target=self.addAccounts, daemon=True)
-            th.start()
-        else:
-            self.LogWrite("Файл logpass.txt уже запущен!")
     def goSettingsF(self):
         self.settingsButton.clicked.connect(lambda: self.goSettings())
     def goSettings(self):
@@ -170,11 +166,20 @@ class Ui_MainWindow(object):
         self.startFarmButton.setText(_translate("MainWindow", "НАЧАТЬ ФАРМ"))
 
     def addAccountsF(self):
-        self.addAccountsButton.clicked.connect(lambda: self.addAccountsT())
+        self.addAccountsButton.clicked.connect(lambda: self.addAccounts())
+    
     def addAccounts(self):
         self.add_acc_stat = True
-        os.system(os.path.abspath('logpass.txt'))
+        file_dialog = QFileDialog()
+        file_dialog.setDirectory("/accounts/pack")
+        file_dialog.setFileMode(QFileDialog.ExistingFile)
+        if file_dialog.exec_() == QFileDialog.Accepted:
+            selected_file_path = file_dialog.selectedFiles()[0]
+            self.file_path = selected_file_path
+        else:
+            return None
         self.add_acc_stat = False
+   
     def addMaFilesF(self):
         self.addMaFilesButton.clicked.connect(lambda: self.addMaFilesT())
     def addMaFiles(self):
@@ -184,7 +189,7 @@ class Ui_MainWindow(object):
         self.checkAccountsButton.clicked.connect(lambda: self.checkAccounts())
     def checkAccounts(self):
         OnStart()
-        CreateAccounts()
+        CreateAccounts(self.file_path)
         self.itemsToLaunch = []
         self.accountsList.clear()
 


### PR DESCRIPTION
1. Открытие файла с помощью менеджера контекста
2. Возможность выбора текстового файла с логинами и паролями. Это позволит разбивать на пачки (например текстовики pack1, pack2  в каждом по 25 аккаунтов).